### PR TITLE
Load Telegram and Bitrix creds from env

### DIFF
--- a/backend/src/api/auth/services/auth.service.ts
+++ b/backend/src/api/auth/services/auth.service.ts
@@ -39,7 +39,7 @@ export class AuthService {
       private configService: ConfigService,
       private readonly roleService: RoleService,
   ) {
-    const telegramToken = '7722439245:AAH5crruoiLpYfiCnQRNUe83gQ55ozx3Og8';
+    const telegramToken = this.configService.get<string>('telegram.botToken');
     // Включаем polling (или можно использовать webhook)
     this.telegramBot = new TelegramBot(telegramToken, { polling: true });
 

--- a/backend/src/api/bitrix/bitrix.service.ts
+++ b/backend/src/api/bitrix/bitrix.service.ts
@@ -9,7 +9,7 @@ export class BitrixService {
     constructor(private configService: ConfigService) {
         // Получаем URL вебхука для доступа к REST API Битрикс24
         // Например: https://yourdomain.bitrix24.ru/rest/1/your_webhook_code
-        this.webhookUrl = 'https://mdline.bitrix24.kz/rest/9/7c7xusn6aab7mls9/';
+        this.webhookUrl = this.configService.get<string>('bitrix.webhookUrl');
     }
 
     /**

--- a/backend/src/common/envs/development.env
+++ b/backend/src/common/envs/development.env
@@ -11,3 +11,5 @@ DATABASE_ENTITIES=dist/**/*.entity.{ts,js}
 ADMIN_EMAIL=admin@admin.com
 ADMIN_PASSWORD=12345678
 DATABASE_SSL=false
+TELEGRAM_BOT_TOKEN=7722439245:AAH5crruoiLpYfiCnQRNUe83gQ55ozx3Og8
+BITRIX_WEBHOOK_URL=https://mdline.bitrix24.kz/rest/9/7c7xusn6aab7mls9/

--- a/backend/src/common/envs/test.env
+++ b/backend/src/common/envs/test.env
@@ -10,3 +10,5 @@ JWT_SECRET=keep-this-secret-private
 DATABASE_ENTITIES=src/**/*.entity.{ts,js}
 ADMIN_EMAIL=admin@admin.com
 ADMIN_PASSWORD=12345678
+TELEGRAM_BOT_TOKEN=7722439245:AAH5crruoiLpYfiCnQRNUe83gQ55ozx3Og8
+BITRIX_WEBHOOK_URL=https://mdline.bitrix24.kz/rest/9/7c7xusn6aab7mls9/

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -20,6 +20,12 @@ export const configuration = () => ({
   jwt: {
     secret: process.env.JWT_SECRET || 'secret',
   },
+  telegram: {
+    botToken: process.env.TELEGRAM_BOT_TOKEN || '',
+  },
+  bitrix: {
+    webhookUrl: process.env.BITRIX_WEBHOOK_URL || '',
+  },
   adminUser: {
     email: process.env.ADMIN_EMAIL || 'admin@admin.com',
     password: process.env.ADMIN_PASSWORD || '12345678',


### PR DESCRIPTION
## Summary
- configure Telegram bot token and Bitrix webhook URL via environment variables
- use ConfigService to load the Telegram token
- read Bitrix webhook URL from configuration
- document new env vars in sample env files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2fc4a5048326b27d80a5bdba4b60