### PR TITLE
Implement UpdateRentalDto and CurrencySeeder

### DIFF
--- a/backend/src/api/rental/dto/update-rental.dto.ts
+++ b/backend/src/api/rental/dto/update-rental.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateRentalDto } from './create-rental.dto';
+
+export class UpdateRentalDto extends PartialType(CreateRentalDto) {}

--- a/backend/src/database/seed/seeders/currency.seeder.ts
+++ b/backend/src/database/seed/seeders/currency.seeder.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SeederInterface } from '../seeder.interface';
+import { Currency } from '../../../api/currency/entities/currency.entity';
+
+@Injectable()
+export class CurrencySeeder implements SeederInterface {
+  constructor(
+    @InjectRepository(Currency)
+    private readonly currencyRepository: Repository<Currency>,
+  ) {}
+
+  async seed() {
+    const data: Partial<Currency>[] = this.generateData();
+    await this.currencyRepository.upsert(data, {
+      conflictPaths: ['code'],
+    });
+  }
+
+  generateData(): Partial<Currency>[] {
+    const codes = ['USD', 'KZT', 'BYN'];
+    return codes.map((code) => ({ code }));
+  }
+}


### PR DESCRIPTION
## Summary
- add UpdateRentalDto using PartialType
- create CurrencySeeder to populate default currencies

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685d2fc7047c8326831b7ea1db8665d4