### PR TITLE
Use config base URL for upload paths

### DIFF
--- a/backend/src/api/auth/controllers/auth.controller.ts
+++ b/backend/src/api/auth/controllers/auth.controller.ts
@@ -5,6 +5,7 @@ import {
   UseInterceptors,
   UploadedFiles,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { AuthService } from '../services/auth.service';
 import { RegisterDto } from '../dto/auth.dto';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
@@ -14,7 +15,10 @@ import { File as MulterFile } from 'multer'; // Переименование т�
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly configService: ConfigService,
+  ) {}
 
   @Post('sendCode')
   sendCode(@Body('phoneNumber') phoneNumber: string) {
@@ -69,13 +73,15 @@ export class AuthController {
     if (files.photoIdFront && files.photoIdFront.length > 0) {
       const fileFront = files.photoIdFront[0];
       // Формируем URL для хранения пути к файлу в БД
-      user.idCardFrontImage = `http://localhost:4000/uploads/users/${fileFront.filename}`;
+      const baseUrl = this.configService.get<string>('baseUrl');
+      user.idCardFrontImage = `${baseUrl}/uploads/users/${fileFront.filename}`;
     }
 
     // Если загружена задняя сторона удостоверения
     if (files.photoIdBack && files.photoIdBack.length > 0) {
       const fileBack = files.photoIdBack[0];
-      user.idCardBackImage = `http://localhost:4000/uploads/users/${fileBack.filename}`;
+      const baseUrl = this.configService.get<string>('baseUrl');
+      user.idCardBackImage = `${baseUrl}/uploads/users/${fileBack.filename}`;
     }
 
     return this.authService.register(user);

--- a/backend/src/api/bike/controllers/bike.controller.ts
+++ b/backend/src/api/bike/controllers/bike.controller.ts
@@ -9,6 +9,7 @@ import {
     UseInterceptors,
     UploadedFiles,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { BikeService } from '../services/bike.service';
 import { Bike } from '../entities/bike.entity';
 import {CreateBikeDto, CreateBikeTranslationDto} from '../dto/create-bike.dto';
@@ -21,7 +22,10 @@ import { BikePriceDto } from '../dto/create-bike.dto';
 
 @Controller('bikes')
 export class BikeController {
-    constructor(private readonly bikeService: BikeService) {}
+    constructor(
+        private readonly bikeService: BikeService,
+        private readonly configService: ConfigService,
+    ) {}
 
     @Get()
     async getAllBikes(): Promise<Bike[]> {
@@ -64,8 +68,9 @@ export class BikeController {
         console.log(JSON.stringify(bikeData, null, 2));
 
         if (files.photos && files.photos.length > 0) {
+            const baseUrl = this.configService.get<string>('baseUrl');
             bikeData.imageUrls = files.photos.map(
-                (file) => `http://localhost:4000/uploads/bikes/${file.filename}`,
+                (file) => `${baseUrl}/uploads/bikes/${file.filename}`,
             );
         }
 
@@ -142,8 +147,9 @@ export class BikeController {
     ): Promise<Bike> {
         // если пришли новые фото — дописываем их к imageUrls
         if (files.photos?.length) {
+            const baseUrl = this.configService.get<string>('baseUrl');
             const urls = files.photos.map(
-                f => `http://localhost:4000/uploads/bikes/${f.filename}`,
+                f => `${baseUrl}/uploads/bikes/${f.filename}`,
             );
             bikeData.imageUrls = [
                 ...(bikeData.imageUrls as string[] || []),


### PR DESCRIPTION
## Summary
- read server base URL from configuration
- generate uploaded file URLs using `baseUrl` in auth and bike controllers

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d2fc7ebc0832695b902e4172a4d57