### PR TITLE
Add auth decorators to controllers

### DIFF
--- a/backend/src/api/bike/controllers/bike.controller.ts
+++ b/backend/src/api/bike/controllers/bike.controller.ts
@@ -18,6 +18,8 @@ import { extname } from 'path';
 import { File as MulterFile } from 'multer';
 import { plainToInstance } from 'class-transformer';
 import { BikePriceDto } from '../dto/create-bike.dto';
+import { Auth } from '../../auth/guards/auth.decorator';
+import { RoleIds } from '../../role/enum/role.enum';
 
 @Controller('bikes')
 export class BikeController {
@@ -34,6 +36,7 @@ export class BikeController {
     }
 
     // Эндпоинт для создания велосипеда с загрузкой фотографий
+    @Auth(RoleIds.Admin)
     @Post()
     @UseInterceptors(
         FileFieldsInterceptor([{ name: 'photos', maxCount: 5 }], {
@@ -113,6 +116,7 @@ export class BikeController {
     }
 
 
+    @Auth(RoleIds.Admin)
     @Put(':id')
     @UseInterceptors(
         FileFieldsInterceptor(
@@ -183,6 +187,7 @@ export class BikeController {
         return this.bikeService.updateBike(id, bikeData);
     }
 
+    @Auth(RoleIds.Admin)
     @Delete(':id')
     async deleteBike(@Param('id') id: number): Promise<void> {
         return this.bikeService.deleteBike(id);

--- a/backend/src/api/payment/controllers/payment.controller.ts
+++ b/backend/src/api/payment/controllers/payment.controller.ts
@@ -2,26 +2,32 @@ import { Controller, Post, Get, Patch, Param, Body } from '@nestjs/common';
 import { PaymentService } from '../services/payment.service';
 import { CreatePaymentDto } from '../dto/create-payment.dto';
 import { Payment } from '../entities/payment.entity';
+import { Auth } from '../../auth/guards/auth.decorator';
+import { RoleIds } from '../../role/enum/role.enum';
 
 @Controller('payments')
 export class PaymentController {
     constructor(private readonly paymentService: PaymentService) {}
 
+    @Auth()
     @Post()
     async createPayment(@Body() createPaymentDto: CreatePaymentDto): Promise<Payment> {
         return this.paymentService.createPayment(createPaymentDto);
     }
 
+    @Auth()
     @Get('/user/:userId')
     async getPaymentsByUser(@Param('userId') userId: number): Promise<Payment[]> {
         return this.paymentService.getPaymentsByUser(userId);
     }
 
+    @Auth(RoleIds.Admin)
     @Get('/rental/:rentalId')
     async getPaymentsByRental(@Param('rentalId') rentalId: number): Promise<Payment[]> {
         return this.paymentService.getPaymentsByRental(rentalId);
     }
 
+    @Auth(RoleIds.Admin)
     @Patch('/:id/status')
     async updatePaymentStatus(
         @Param('id') id: number,

--- a/backend/src/api/rental/controllers/rental.controller.ts
+++ b/backend/src/api/rental/controllers/rental.controller.ts
@@ -1,5 +1,7 @@
 import { Controller, Post, Patch, Param, Body, Get } from '@nestjs/common';
 import { ParseIntPipe } from '@nestjs/common';
+import { Auth } from '../../auth/guards/auth.decorator';
+import { RoleIds } from '../../role/enum/role.enum';
 import { RentalService } from '../services/rental.service';
 import { CreateRentalDto } from '../dto/create-rental.dto';
 import { Rental } from '../entities/rental.entity';
@@ -8,46 +10,55 @@ import { Rental } from '../entities/rental.entity';
 export class RentalController {
     constructor(private readonly rentalService: RentalService) {}
 
+    @Auth()
     @Post()
     async createRental(@Body() createRentalDto: CreateRentalDto): Promise<Rental> {
         return this.rentalService.createRental(createRentalDto);
     }
 
+    @Auth(RoleIds.Admin)
     @Patch(':id/complete')
     async completeRental(@Param('id', ParseIntPipe) id: number): Promise<Rental> {
         return this.rentalService.completeRental(id);
     }
 
+    @Auth(RoleIds.Admin)
     @Get()
     async getAllRentals(): Promise<Rental[]> {
         return this.rentalService.getAllRentals();
     }
 
+    @Auth(RoleIds.Admin)
     @Get('/active')
     async getActiveRentals(): Promise<Rental[]> {
         return this.rentalService.getActiveRentals();
     }
 
+    @Auth()
     @Get('/user/:userId')
     async getRentalsByUser(@Param('userId') userId: number): Promise<Rental[]> {
         return this.rentalService.getRentalsByUser(userId);
     }
 
+    @Auth()
     @Get('/user/:userId/history')
     async getUserRentalHistory(@Param('userId') userId: number): Promise<Rental[]> {
         return this.rentalService.getUserRentalHistory(userId);
     }
 
+    @Auth(RoleIds.Admin)
     @Patch(':id/activate')
     async activateRental(@Param('id', ParseIntPipe) id: number): Promise<Rental> {
         return this.rentalService.activateRental(id);
     }
 
+    @Auth(RoleIds.Admin)
     @Patch(':id/cancel')
     async cancelRental(@Param('id') id: number): Promise<Rental> {
         return this.rentalService.cancelRental(id);
     }
 
+    @Auth(RoleIds.Admin)
     @Get(':id')
     async getRentalById(@Param('id') id: number): Promise<Rental> {
         return this.rentalService.getRentalById(id);


### PR DESCRIPTION
## Summary
- secure bike endpoints for admin use
- restrict rental and payment operations with auth guards

## Testing
- `npm --prefix backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2fc9102483269a7164fb530ba91f