### PR TITLE
Refactor user creation

### DIFF
--- a/backend/src/api/admin/admin.module.ts
+++ b/backend/src/api/admin/admin.module.ts
@@ -6,11 +6,13 @@ import { User } from '../../database/entities/user.entity';
 import { Bike } from '../bike/entities/bike.entity';
 import {Rental} from "../rental/entities/rental.entity";
 import {RoleModule} from "../role/role.module";
+import {UserModule} from "../user/user.module";
 
 @Module({
     imports: [
         TypeOrmModule.forFeature([User, Bike, Rental]),
         RoleModule,
+        UserModule,
     ],
     controllers: [AdminController],
     providers: [AdminService],

--- a/backend/src/api/user/services/user.service.ts
+++ b/backend/src/api/user/services/user.service.ts
@@ -17,8 +17,14 @@ export class UserService {
       body: CreateUserDto,
       ...roles: Role[]
   ): Promise<User> {
+    const data: Partial<User> = { ...body };
+
+    if (body.password) {
+      data.password = await hash(body.password, 10);
+    }
+
     const user: User = this.repository.create({
-      ...body,
+      ...data,
       roles,
     });
 


### PR DESCRIPTION
## Summary
- hash passwords in `UserService.createUser`
- call centralized user creation from admin service
- include `UserModule` in `AdminModule`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685d2fca76fc83268089e56de5c2c7e3