### PR TITLE
Add basic e2e tests for additional modules

### DIFF
--- a/backend/test/api/accessories/index.e2e-spec.ts
+++ b/backend/test/api/accessories/index.e2e-spec.ts
@@ -1,0 +1,27 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../../../src/app.module';
+
+describe('AccessoriesController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('/accessories (GET)', async () => {
+    const response = await request(app.getHttpServer()).get('/accessories');
+    expect(response.status).toBe(200);
+    expect(response.body.isSuccess).toBe(true);
+  });
+});

--- a/backend/test/api/bike/index.e2e-spec.ts
+++ b/backend/test/api/bike/index.e2e-spec.ts
@@ -1,0 +1,27 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../../../src/app.module';
+
+describe('BikeController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('/bikes (GET)', async () => {
+    const response = await request(app.getHttpServer()).get('/bikes');
+    expect(response.status).toBe(200);
+    expect(response.body.isSuccess).toBe(true);
+  });
+});

--- a/backend/test/api/payment/index.e2e-spec.ts
+++ b/backend/test/api/payment/index.e2e-spec.ts
@@ -1,0 +1,27 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../../../src/app.module';
+
+describe('PaymentController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('/payments/user/1 (GET)', async () => {
+    const response = await request(app.getHttpServer()).get('/payments/user/1');
+    expect(response.status).toBe(200);
+    expect(response.body.isSuccess).toBe(true);
+  });
+});

--- a/backend/test/api/rental/index.e2e-spec.ts
+++ b/backend/test/api/rental/index.e2e-spec.ts
@@ -1,0 +1,27 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../../../src/app.module';
+
+describe('RentalController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('/rentals (GET)', async () => {
+    const response = await request(app.getHttpServer()).get('/rentals');
+    expect(response.status).toBe(200);
+    expect(response.body.isSuccess).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- create e2e tests for bikes, rentals, payments and accessories modules

## Testing
- `npm run test:e2e` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2fcbe8f88326b0de6d87c5bf94e4