### PR TITLE
Refactor TypeORM config to use ConfigService

### DIFF
--- a/backend/src/database/typeorm/typeOrm.config.ts
+++ b/backend/src/database/typeorm/typeOrm.config.ts
@@ -2,21 +2,29 @@ import { config } from 'dotenv';
 import { resolve } from 'path';
 import { getEnvPath } from '../../common/helper/env.helper';
 import { DataSourceOptions } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { configuration } from '../../config';
 
 const envFilePath: string = getEnvPath(
   resolve(__dirname, '../..', 'common/envs'),
 );
 config({ path: envFilePath });
-export const dataSourceOptions: DataSourceOptions = {
+
+export const createDataSourceOptions = (
+  configService: ConfigService,
+): DataSourceOptions => ({
   type: 'postgres',
-  host: 'localhost',
-  port: parseInt(process.env.DATABASE_PORT, 10) || 5432,
-  database: 'ecommercedb',
-  username: 'postgres',
-  password: 'password',
-  entities: [process.env.DATABASE_ENTITIES],
+  host: configService.get<string>('database.host'),
+  port: configService.get<number>('database.port'),
+  database: configService.get<string>('database.name'),
+  username: configService.get<string>('database.user'),
+  password: configService.get<string>('database.password'),
+  entities: [configService.get<string>('database.entities')],
   migrations: ['dist/database/migration/history/*.js'],
   logger: 'simple-console',
   synchronize: false, // never use TRUE in production!
   logging: true, // for debugging in dev Area only
-};
+});
+
+const configService = new ConfigService(configuration());
+export const dataSourceOptions = createDataSourceOptions(configService);

--- a/backend/src/database/typeorm/typeorm.service.ts
+++ b/backend/src/database/typeorm/typeorm.service.ts
@@ -1,10 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { TypeOrmOptionsFactory, TypeOrmModuleOptions } from '@nestjs/typeorm';
-import { dataSourceOptions } from './typeOrm.config';
+import { ConfigService } from '@nestjs/config';
+import { createDataSourceOptions } from './typeOrm.config';
 
 @Injectable()
 export class TypeOrmConfigService implements TypeOrmOptionsFactory {
+  constructor(private readonly configService: ConfigService) {}
+
   public createTypeOrmOptions(): TypeOrmModuleOptions {
-    return dataSourceOptions;
+    return createDataSourceOptions(this.configService);
   }
 }


### PR DESCRIPTION
## Summary
- fetch DB options via ConfigService for a single source of truth
- provide a factory to create `DataSourceOptions`
- update `TypeOrmConfigService` to use the factory

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2fcc67208326b197e28489a0acfb