### PR TITLE
Fix repeated fetches & remove process import

### DIFF
--- a/frontend/app/(car-singles)/bike/[id]/page.jsx
+++ b/frontend/app/(car-singles)/bike/[id]/page.jsx
@@ -2,7 +2,6 @@ import Single1 from '@/components/carSingles/Single1';
 import Header6 from '@/components/headers/Header6';
 import Footer1 from '@/components/footers/Footer1';
 import Footer3 from '@/components/footers/Footer3';
-import process from 'next/dist/build/webpack/loaders/resolve-url-loader/lib/postcss';
 
 /**
  * Функция generateStaticParams возвращает список параметров для генерации

--- a/frontend/app/orders/[id]/page.jsx
+++ b/frontend/app/orders/[id]/page.jsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import Header6 from '@/components/headers/Header6';
 import OrderDetails from '@/components/orders/Orders';
-import process from 'next/dist/build/webpack/loaders/resolve-url-loader/lib/postcss';
 
 // Если используете metadata:
 export const metadata = {

--- a/frontend/components/carListings/MapComponent.jsx
+++ b/frontend/components/carListings/MapComponent.jsx
@@ -195,7 +195,7 @@ export default function ListingMap1() {
   const [getLocation, setLocation] = useState(null);
 
   const { isLoaded } = useLoadScript({
-    googleMapsApiKey: 'AIzaSyAAz77U5XQuEME6TpftaMdX0bBelQxXRlM',
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
   });
   const center = useMemo(() => ({ lat: 27.411201277163975, lng: -96.12394824867293 }), []);
 

--- a/frontend/components/dashboard/admin/DashboardAdmin.jsx
+++ b/frontend/components/dashboard/admin/DashboardAdmin.jsx
@@ -28,7 +28,6 @@ import {
   Legend,
 } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
-import process from 'next/dist/build/webpack/loaders/resolve-url-loader/lib/postcss';
 
 // Регистрируем компоненты Chart.js
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
@@ -85,7 +84,7 @@ export default function DashboardAdmin() {
     }
 
     fetchAnalytics();
-  });
+  }, [API_URL]);
 
   // Формируем массив статистики на основе analytics
   const stats = [

--- a/frontend/components/orders/AdminOrderDetails.jsx
+++ b/frontend/components/orders/AdminOrderDetails.jsx
@@ -45,7 +45,7 @@ export default function AdminOrderDetails({ orderId }) {
     if (orderId) {
       fetchOrder();
     }
-  });
+  }, [orderId, API_URL]);
 
   // Устанавливаем текущий статус после загрузки заказа
   useEffect(() => {

--- a/frontend/components/shop/checkout/Checkout.jsx
+++ b/frontend/components/shop/checkout/Checkout.jsx
@@ -8,7 +8,6 @@ import { BillingDetails } from './BillingDetails';
 import { OrderSummary } from './OrderSummary';
 import { PaymentOptions } from './PaymentOptions';
 import { useCart } from '@/context/CartContext';
-import process from 'next/dist/build/webpack/loaders/resolve-url-loader/lib/postcss';
 
 export default function Checkout() {
   const { t } = useTranslation();

--- a/frontend/context/Context.jsx
+++ b/frontend/context/Context.jsx
@@ -78,7 +78,7 @@ export default function Context({ children }) {
       }
     };
     fetchProducts();
-  });
+  }, [API_URL]);
 
   // Пересчёт итоговой суммы корзины
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid repeated product fetches in Context
- fetch admin analytics only once
- load order details once on mount
- pull Maps API key from env
- drop bogus `process` imports

## Testing
- `npm run lint` *(fails: prettier errors in unrelated files)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cea134be08326a8c25a6604f65ea0