### PR TITLE
Ensure consistent RTK Query usage

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## State Management
+
+This project uses **Redux Toolkit Query** for API interactions. The store is initialized in `store/store.js` and provided in `app/layout.jsx`.

--- a/frontend/app/layout.jsx
+++ b/frontend/app/layout.jsx
@@ -9,6 +9,8 @@ import RootContext from '@/context/RootContext';
 import BackToTop from '@/components/common/BackToTop';
 import { I18nextProvider } from 'react-i18next';
 import i18n from './i18n';
+import { Provider } from 'react-redux';
+import { store } from '@/store/store';
 
 import { Roboto } from 'next/font/google';
 
@@ -23,14 +25,16 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en" className={roboto.className}>
       <body>
-        <I18nextProvider i18n={i18n}>
-          <RootContext>
-            <MobileMenu />
-            <div className="boxcar-wrapper">{children}</div>
-            <FilterSidebar />
-          </RootContext>
-          <BackToTop />
-        </I18nextProvider>
+        <Provider store={store}>
+          <I18nextProvider i18n={i18n}>
+            <RootContext>
+              <MobileMenu />
+              <div className="boxcar-wrapper">{children}</div>
+              <FilterSidebar />
+            </RootContext>
+            <BackToTop />
+          </I18nextProvider>
+        </Provider>
       </body>
     </html>
   );

--- a/frontend/components/carListings/Listings1.jsx
+++ b/frontend/components/carListings/Listings1.jsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Image from 'next/image';
 import SelectComponent from '../common/SelectComponent';
 import Pagination from '../common/Pagination';
@@ -10,33 +10,14 @@ import { AiOutlineLoading } from 'react-icons/ai';
 import Button from '@/components/ui/button/Button';
 // Импортируем контекст корзины
 import { useCart } from '@/context/CartContext';
+import { useGetBikesQuery } from '@/store/services/bikesApi';
 
 export default function Listings1() {
   const { addProductToCart, isAddedToCartProducts } = useCart();
-  const [bikes, setBikes] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [loadingBikeId, setLoadingBikeId] = useState(null);
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+  const { data, error, isLoading } = useGetBikesQuery();
+  const [loadingBikeId, setLoadingBikeId] = React.useState(null);
+  const bikes = Array.isArray(data?.data) ? data.data : [];
   const router = useRouter();
-
-  useEffect(() => {
-    const fetchBikes = async () => {
-      setLoading(true);
-      try {
-        const response = await fetch(`${API_URL}/bikes/`);
-        const result = await response.json();
-        console.log('Fetched bikes:', result);
-        const bikesData = Array.isArray(result.data) ? result.data : [];
-        setBikes(bikesData);
-      } catch (error) {
-        console.error('Error fetching bikes:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchBikes();
-  }, [API_URL]);
 
   const handleRent = id => {
     setLoadingBikeId(id);
@@ -44,7 +25,7 @@ export default function Listings1() {
     router.push(`/bike/${id}`);
   };
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex justify-center items-center h-80">
         <AiOutlineLoading size={60} className="animate-spin" />

--- a/frontend/components/dashboard/admin/DashboardAdmin.jsx
+++ b/frontend/components/dashboard/admin/DashboardAdmin.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import { useGetAnalyticsQuery } from '@/store/services/adminApi';
 import { useRouter } from 'next/navigation';
 import '../../../public/css/pages/login/Login.css';
 
@@ -60,32 +61,16 @@ export default function DashboardAdmin() {
 
   // Период для графика: "oneWeek", "twoWeeks", "oneMonth"
   const [selectedPeriod, setSelectedPeriod] = useState('oneWeek');
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+  const { data: analyticsData, error: analyticsError } = useGetAnalyticsQuery();
 
-  // useEffect для загрузки данных аналитики
   useEffect(() => {
-    async function fetchAnalytics() {
-      try {
-        const token = localStorage.getItem('accessToken');
-        const response = await fetch(`${API_URL}/admin/analytics`, {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
-        });
-        const data = await response.json();
-        if (data.isSuccess) {
-          setAnalytics(data.data);
-        } else {
-          console.error('Ошибка загрузки аналитики:', data.message);
-        }
-      } catch (error) {
-        console.error('Ошибка при запросе аналитики:', error);
-      }
+    if (analyticsData?.data) {
+      setAnalytics(analyticsData.data);
     }
-
-    fetchAnalytics();
-  });
+    if (analyticsError) {
+      console.error('Ошибка загрузки аналитики:', analyticsError);
+    }
+  }, [analyticsData, analyticsError]);
 
   // Формируем массив статистики на основе analytics
   const stats = [

--- a/frontend/components/dashboard/admin/tabs/CouriersTab.jsx
+++ b/frontend/components/dashboard/admin/tabs/CouriersTab.jsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import NextLink from 'next/link';
+import { useGetCouriersQuery } from '@/store/services/adminApi';
 import {
   Box,
   Typography,
@@ -16,26 +17,8 @@ import {
 } from '@mui/material';
 
 export default function CouriersTab() {
-  const [couriers, setCouriers] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
-
-  useEffect(() => {
-    (async () => {
-      try {
-        const res = await fetch(`${API_URL}/couriers`);
-        if (!res.ok) throw new Error('Не удалось загрузить курьеров');
-        const result = await res.json();
-        setCouriers(result.data || []);
-      } catch (err) {
-        console.error(err);
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, [API_URL]);
+  const { data, isLoading: loading, error } = useGetCouriersQuery();
+  const couriers = Array.isArray(data?.data) ? data.data : [];
 
   if (loading) {
     return (

--- a/frontend/components/dashboard/admin/tabs/OrdersTab.jsx
+++ b/frontend/components/dashboard/admin/tabs/OrdersTab.jsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
+import { useGetRentalsQuery } from '@/store/services/rentalsApi';
 import NextLink from 'next/link';
 import {
   Box,
@@ -22,28 +23,11 @@ import {
 import InfoIcon from '@mui/icons-material/Info';
 
 export default function OrdersTab() {
-  const [rentals, setRentals] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+  const { data, isLoading, error } = useGetRentalsQuery();
+  const rentals = Array.isArray(data?.data) ? data.data : [];
 
-  useEffect(() => {
-    (async () => {
-      try {
-        const response = await fetch(`${API_URL}/rentals/`);
-        if (!response.ok) throw new Error('Не удалось загрузить данные об арендах');
-        const data = await response.json();
-        setRentals(data.data || []);
-      } catch (err) {
-        console.error(err);
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, [API_URL]);
 
-  if (loading) {
+  if (isLoading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
         <CircularProgress />

--- a/frontend/components/dashboard/admin/tabs/UsersTab.jsx
+++ b/frontend/components/dashboard/admin/tabs/UsersTab.jsx
@@ -30,7 +30,7 @@ export default function UsersTab() {
 
   useEffect(() => {
     fetchUsers();
-  });
+  }, []);
 
   async function fetchUsers() {
     setLoading(true);

--- a/frontend/components/dashboard/admin/tabs/accessories/AccessoriesTab.jsx
+++ b/frontend/components/dashboard/admin/tabs/accessories/AccessoriesTab.jsx
@@ -6,9 +6,11 @@ import AccessoriesTable from './AccessoriesTable';
 import AccessoryForm from './AccessoryForm';
 import { Box, Typography, Button, CircularProgress } from '@mui/material';
 import Alert from '@mui/material/Alert';
+import { useGetBikesQuery } from '@/store/services/bikesApi';
 
 export default function AccessoriesTab() {
   const [accessories, setAccessories] = useState([]);
+  const { data: bikesData, error: bikesError } = useGetBikesQuery();
   const [bikes, setBikes] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -27,8 +29,14 @@ export default function AccessoriesTab() {
 
   useEffect(() => {
     fetchAccessories();
-    fetchBikes();
-  });
+  }, []);
+
+  useEffect(() => {
+    if (bikesData?.data) {
+      setBikes(Array.isArray(bikesData.data) ? bikesData.data : []);
+    }
+    if (bikesError) console.error('Ошибка загрузки велосипедов:', bikesError);
+  }, [bikesData, bikesError]);
 
   async function fetchAccessories() {
     setLoading(true);
@@ -47,16 +55,6 @@ export default function AccessoriesTab() {
     }
   }
 
-  async function fetchBikes() {
-    try {
-      const response = await fetch(`${API_URL}/bikes`);
-      if (!response.ok) throw new Error('Ошибка при получении велосипедов');
-      const result = await response.json();
-      if (result.isSuccess) setBikes(result.data || []);
-    } catch (err) {
-      console.error(err);
-    }
-  }
 
   const handleAddAccessory = () => {
     setIsEditMode(false);

--- a/frontend/components/dashboard/admin/tabs/bikes/BikesTab.jsx
+++ b/frontend/components/dashboard/admin/tabs/bikes/BikesTab.jsx
@@ -38,7 +38,7 @@ export default function BikesTab() {
   useEffect(() => {
     fetchBikes();
     fetchPriceCategories();
-  });
+  }, []);
 
   async function fetchBikes() {
     try {

--- a/frontend/components/dashboard/corporate/tabs/RentTab.jsx
+++ b/frontend/components/dashboard/corporate/tabs/RentTab.jsx
@@ -1,34 +1,14 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { FiEye } from 'react-icons/fi';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
+import { useGetRentalsQuery } from '@/store/services/rentalsApi';
 
 export default function RentTab() {
   const router = useRouter();
-  const [rentals, setRentals] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
-
-  useEffect(() => {
-    async function fetchRentals() {
-      try {
-        const response = await fetch(`${API_URL}/rentals/`);
-        if (!response.ok) {
-          throw new Error('Не удалось загрузить данные об арендах');
-        }
-        const data = await response.json();
-        // Ожидаем структуру { isSuccess, message, data: [...] }
-        setRentals(data.data || []);
-      } catch (err) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    }
-    fetchRentals();
-  });
+  const { data, isLoading: loading, error } = useGetRentalsQuery();
+  const rentals = Array.isArray(data?.data) ? data.data : [];
 
   if (loading) {
     return <p className="p-4">Загрузка заказов...</p>;

--- a/frontend/components/dashboard/corporate/tabs/dashboard/NoActiveOrderTiles.jsx
+++ b/frontend/components/dashboard/corporate/tabs/dashboard/NoActiveOrderTiles.jsx
@@ -1,36 +1,17 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Button from '@/components/ui/button/Button';
 import { AiOutlineLoading } from 'react-icons/ai';
 import Image from 'next/image';
+import { useGetBikesQuery } from '@/store/services/bikesApi';
 
 export default function NoActiveOrderTiles() {
-  const [bikes, setBikes] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const { data, isLoading, error } = useGetBikesQuery();
+  const bikes = Array.isArray(data?.data) ? data.data : [];
+  if (error) console.error('Ошибка загрузки байков:', error);
   const [loadingBikeId, setLoadingBikeId] = useState(null);
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
   const router = useRouter();
-
-  useEffect(() => {
-    const fetchBikes = async () => {
-      setIsLoading(true);
-      try {
-        const res = await fetch(`${API_URL}/bikes`);
-        const data = await res.json();
-        if (data.isSuccess) {
-          setBikes(data.data);
-        } else {
-          console.error('Произошла ошибка при получении байков:', data);
-        }
-      } catch (error) {
-        console.error('Произошла ошибка при загрузке:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    fetchBikes();
-  }, [API_URL]);
 
   const handleRent = id => {
     setLoadingBikeId(id);

--- a/frontend/components/dashboard/courier/tabs/RentTab.jsx
+++ b/frontend/components/dashboard/courier/tabs/RentTab.jsx
@@ -1,36 +1,18 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+import React from 'react';
+import { useGetRentalsQuery } from '@/store/services/rentalsApi';
 import { FiEye } from 'react-icons/fi';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 
 export default function RentTab() {
   const router = useRouter();
-  const [rentals, setRentals] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+  const { data, isLoading, error } = useGetRentalsQuery();
+  const rentals = Array.isArray(data?.data) ? data.data : [];
 
-  useEffect(() => {
-    async function fetchRentals() {
-      try {
-        const response = await fetch(`${API_URL}/rentals/`);
-        if (!response.ok) {
-          throw new Error('Не удалось загрузить данные об арендах');
-        }
-        const data = await response.json();
-        // Ожидаем структуру { isSuccess, message, data: [...] }
-        setRentals(data.data || []);
-      } catch (err) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    }
-    fetchRentals();
-  });
+  // RTK Query already загружает аренды
 
-  if (loading) {
+  if (isLoading) {
     return <p className="p-4">Загрузка заказов...</p>;
   }
 

--- a/frontend/components/dashboard/courier/tabs/dashboard/NoActiveOrderTiles.jsx
+++ b/frontend/components/dashboard/courier/tabs/dashboard/NoActiveOrderTiles.jsx
@@ -1,35 +1,17 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Button from '@/components/ui/button/Button';
 import { AiOutlineLoading } from 'react-icons/ai';
 import Image from 'next/image';
+import { useGetBikesQuery } from '@/store/services/bikesApi';
 
 export default function NoActiveOrderTiles() {
-  const [bikes, setBikes] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const { data, isLoading, error } = useGetBikesQuery();
+  const bikes = Array.isArray(data?.data) ? data.data : [];
   const [loadingBikeId, setLoadingBikeId] = useState(null);
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
   const router = useRouter();
-
-  useEffect(() => {
-    setIsLoading(true);
-    fetch(`${API_URL}/bikes`)
-      .then(res => res.json())
-      .then(data => {
-        if (data.isSuccess) {
-          setBikes(data.data);
-        } else {
-          console.error('Произошла ошибка при получении байков:', data);
-        }
-      })
-      .catch(error => {
-        console.error('Произошла ошибка при загрузке:', error);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  }, [API_URL]);
+  if (error) console.error('Ошибка загрузки байков:', error);
 
   const handleRent = id => {
     setLoadingBikeId(id);

--- a/frontend/components/homes/home-6/Cars.jsx
+++ b/frontend/components/homes/home-6/Cars.jsx
@@ -7,6 +7,7 @@ import Button from '@/components/ui/button/Button';
 import { IoIosArrowDown } from 'react-icons/io';
 import { AiOutlineLoading } from 'react-icons/ai';
 import { useRouter } from 'next/navigation';
+import { useGetBikesQuery } from '@/store/services/bikesApi';
 
 const buttons = [
   { label: 'New cars', isActive: true },
@@ -16,41 +17,30 @@ const buttons = [
 
 export default function Cars() {
   const router = useRouter();
-  const [bikes, setBikes] = useState([]);
+  const { data, isLoading, error } = useGetBikesQuery();
+  const bikes = Array.isArray(data?.data) ? data.data : [];
   const [selectedCategory, setSelectedCategory] = useState(buttons[0]);
-  const [isLoading, setIsLoading] = useState(true);
   const [isMobile, setIsMobile] = useState(false);
   const [isInnerTouchActive, setIsInnerTouchActive] = useState(false);
   const [rentingBikeId, setRentingBikeId] = useState(null);
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+  if (error) console.error('Ошибка загрузки байков:', error);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-40">
+        <AiOutlineLoading size={60} className="animate-spin" />
+      </div>
+    );
+  }
 
   useEffect(() => {
-    const fetchBikes = async () => {
-      try {
-        const response = await fetch(`${API_URL}/bikes/`);
-        if (!response.ok) {
-          throw new Error('Ошибка при загрузке данных о байках');
-        }
-        const result = await response.json();
-        // Сортируем байки по id
-        const sortedBikes = result.data.sort((a, b) => a.id - b.id);
-        setBikes(sortedBikes);
-      } catch (error) {
-        console.error('Ошибка:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchBikes();
-
     const handleResize = () => {
       setIsMobile(window.innerWidth < 768);
     };
     handleResize();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, [API_URL]);
+  }, []);
 
   const handleRentClick = bikeId => {
     setRentingBikeId(bikeId);

--- a/frontend/components/orders/AdminOrderDetails.jsx
+++ b/frontend/components/orders/AdminOrderDetails.jsx
@@ -16,36 +16,21 @@ import {
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useRouter } from 'next/navigation';
+import {
+  useGetRentalByIdQuery,
+  useUpdateRentalStatusMutation,
+} from '@/store/services/rentalsApi';
 
 export default function AdminOrderDetails({ orderId }) {
-  const [order, setOrder] = useState(null);
+  const { data, isLoading: loading, error } = useGetRentalByIdQuery(orderId, {
+    skip: !orderId,
+  });
+  const [updateStatus] = useUpdateRentalStatusMutation();
+  const order = data?.data || null;
   const [newStatus, setNewStatus] = useState('');
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
   const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
   const router = useRouter();
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
-
-  useEffect(() => {
-    async function fetchOrder() {
-      try {
-        const response = await fetch(`${API_URL}/rentals/${orderId}`);
-        if (!response.ok) {
-          throw new Error('Не удалось загрузить детали заказа');
-        }
-        const data = await response.json();
-        // Ожидаем, что данные приходят в виде { isSuccess, message, data: { ... } }
-        setOrder(data.data);
-      } catch (err) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    }
-    if (orderId) {
-      fetchOrder();
-    }
-  });
+  // Обновляем статус заказа
 
   // Устанавливаем текущий статус после загрузки заказа
   useEffect(() => {
@@ -60,19 +45,13 @@ export default function AdminOrderDetails({ orderId }) {
 
   const handleStatusUpdate = async () => {
     try {
-      const response = await fetch(`${API_URL}/rentals/${order.id}/status`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ status: newStatus }),
-      });
-      if (!response.ok) {
-        throw new Error('Ошибка обновления статуса заказа');
-      }
-      const updatedData = await response.json();
-      setOrder(updatedData.data);
+      const updated = await updateStatus({ id: order.id, status: newStatus }).unwrap();
       setSnackbar({ open: true, message: 'Статус успешно обновлён', severity: 'success' });
+      // Обновляем локальное состояние
+      if (updated.data) {
+        // обновляем статус в локальном состоянии
+        setNewStatus(updated.data.status);
+      }
     } catch (error) {
       setSnackbar({ open: true, message: error.message, severity: 'error' });
     }

--- a/frontend/components/orders/Orders.jsx
+++ b/frontend/components/orders/Orders.jsx
@@ -1,6 +1,7 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import Image from 'next/image';
+import { useGetRentalByIdQuery } from '@/store/services/rentalsApi';
 
 // Вспомогательная функция для форматирования цены в тенге
 function formatTenge(value) {
@@ -8,32 +9,12 @@ function formatTenge(value) {
 }
 
 export default function OrderDetails({ orderId }) {
-  const [rental, setRental] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
-
-  // Загружаем один конкретный заказ
-  useEffect(() => {
-    async function fetchOrder() {
-      try {
-        const response = await fetch(`${API_URL}/rentals/${orderId}`);
-        if (!response.ok) {
-          throw new Error('Не удалось загрузить данные о заказе');
-        }
-        const data = await response.json();
-        // Ожидаем структуру { isSuccess, message, data: { ... } }
-        setRental(data.data || null);
-      } catch (err) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    }
-    if (orderId) {
-      fetchOrder();
-    }
-  });
+  const {
+    data,
+    isLoading: loading,
+    error,
+  } = useGetRentalByIdQuery(orderId, { skip: !orderId });
+  const rental = data?.data || null;
 
   if (loading) {
     return <p className="p-4">Загрузка заказа...</p>;

--- a/frontend/components/otherPages/auth/other-login/Login.jsx
+++ b/frontend/components/otherPages/auth/other-login/Login.jsx
@@ -5,40 +5,28 @@ import Button from '@/components/ui/button/Button';
 import Link from 'next/link';
 import { AiOutlineLoading } from 'react-icons/ai';
 import '../../../../public/css/pages/login/Login.css';
+import {
+  useOtherLoginMutation,
+  useLazyGetProfileQuery,
+} from '@/store/services/authApi';
 
 export default function CorporateLogin() {
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+  const [login] = useOtherLoginMutation();
+  const [getProfile] = useLazyGetProfileQuery();
 
   const handleCorporateLogin = async e => {
     e.preventDefault();
     setIsLoading(true);
     try {
-      const response = await fetch(`${API_URL}/auth/other-login`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
-      });
-
-      const data = await response.json();
-      if (!response.ok) {
-        throw new Error(data.message || 'Ошибка авторизации');
-      }
+      const data = await login({ email, password }).unwrap();
 
       localStorage.setItem('accessToken', data.data.accessToken);
 
-      const userResponse = await fetch(`${API_URL}/user/profile`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${data.data.accessToken}`,
-        },
-      });
-
-      const userData = await userResponse.json();
+      const userData = await getProfile().unwrap();
       localStorage.setItem('userData', JSON.stringify(userData.data));
 
       const userRoleName = userData.data.roles[0].name;

--- a/frontend/context/CartContext.jsx
+++ b/frontend/context/CartContext.jsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { createContext, useState, useEffect, useContext } from 'react';
+import { useGetBikesQuery } from '@/store/services/bikesApi';
 
 export const CartContext = createContext(null);
 
@@ -12,23 +13,18 @@ export function CartProvider({ children }) {
   const [totalPrice, setTotalPrice] = useState(0);
   const [products, setProducts] = useState([]);
 
-  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+  const { data, error } = useGetBikesQuery();
 
   // Загрузка товаров с API
   useEffect(() => {
-    const fetchProducts = async () => {
-      try {
-        const res = await fetch(`${API_URL}/bikes/`);
-        const json = await res.json();
-        const data = Array.isArray(json.data) ? json.data : [];
-        setProducts(data);
-      } catch (error) {
-        console.error('Ошибка загрузки товаров:', error);
-      }
-    };
-
-    fetchProducts();
-  }, [API_URL]);
+    if (data?.data) {
+      const bikes = Array.isArray(data.data) ? data.data : [];
+      setProducts(bikes);
+    }
+    if (error) {
+      console.error('Ошибка загрузки товаров:', error);
+    }
+  }, [data, error]);
 
   // Загрузка корзины из localStorage
   useEffect(() => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,8 @@
     "primereact": "^10.9.2",
     "prop-types": "^15.8.1",
     "rc-slider": "^11.1.6",
+    "@reduxjs/toolkit": "^2.2.3",
+    "react-redux": "^9.1.2",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",

--- a/frontend/store/services/adminApi.js
+++ b/frontend/store/services/adminApi.js
@@ -1,0 +1,27 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+export const adminApi = createApi({
+  reducerPath: 'adminApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: API_URL,
+    prepareHeaders: headers => {
+      if (typeof localStorage !== 'undefined') {
+        const token = localStorage.getItem('accessToken');
+        if (token) headers.set('Authorization', `Bearer ${token}`);
+      }
+      return headers;
+    },
+  }),
+  endpoints: builder => ({
+    getAnalytics: builder.query({
+      query: () => '/admin/analytics',
+    }),
+    getCouriers: builder.query({
+      query: () => '/couriers',
+    }),
+  }),
+});
+
+export const { useGetAnalyticsQuery, useGetCouriersQuery } = adminApi;

--- a/frontend/store/services/authApi.js
+++ b/frontend/store/services/authApi.js
@@ -1,0 +1,58 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+export const authApi = createApi({
+  reducerPath: 'authApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: API_URL,
+    prepareHeaders: headers => {
+      if (typeof localStorage !== 'undefined') {
+        const token = localStorage.getItem('accessToken');
+        if (token) headers.set('Authorization', `Bearer ${token}`);
+      }
+      return headers;
+    },
+  }),
+  endpoints: builder => ({
+    sendCode: builder.mutation({
+      query: phoneNumber => ({
+        url: '/auth/sendCode',
+        method: 'POST',
+        body: { phoneNumber },
+      }),
+    }),
+    login: builder.mutation({
+      query: ({ phoneNumber, code }) => ({
+        url: '/auth/login',
+        method: 'POST',
+        body: { phoneNumber, code },
+      }),
+    }),
+    otherLogin: builder.mutation({
+      query: ({ email, password }) => ({
+        url: '/auth/other-login',
+        method: 'POST',
+        body: { email, password },
+      }),
+    }),
+    register: builder.mutation({
+      query: body => ({
+        url: '/auth/register',
+        method: 'POST',
+        body,
+      }),
+    }),
+    getProfile: builder.query({
+      query: () => '/user/profile',
+    }),
+  }),
+});
+
+export const {
+  useSendCodeMutation,
+  useLoginMutation,
+  useOtherLoginMutation,
+  useRegisterMutation,
+  useLazyGetProfileQuery,
+} = authApi;

--- a/frontend/store/services/bikesApi.js
+++ b/frontend/store/services/bikesApi.js
@@ -1,0 +1,18 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+export const bikesApi = createApi({
+  reducerPath: 'bikesApi',
+  baseQuery: fetchBaseQuery({ baseUrl: API_URL }),
+  endpoints: builder => ({
+    getBikes: builder.query({
+      query: () => '/bikes/',
+    }),
+    getBikeById: builder.query({
+      query: id => `/bikes/${id}`,
+    }),
+  }),
+});
+
+export const { useGetBikesQuery, useGetBikeByIdQuery } = bikesApi;

--- a/frontend/store/services/rentalsApi.js
+++ b/frontend/store/services/rentalsApi.js
@@ -1,0 +1,37 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+export const rentalsApi = createApi({
+  reducerPath: 'rentalsApi',
+  baseQuery: fetchBaseQuery({ baseUrl: API_URL }),
+  endpoints: builder => ({
+    getRentals: builder.query({
+      query: () => '/rentals/',
+    }),
+    getRentalsByUser: builder.query({
+      query: userId => `/rentals/user/${userId}`,
+    }),
+    getRentalHistoryByUser: builder.query({
+      query: userId => `/rentals/user/${userId}/history`,
+    }),
+    getRentalById: builder.query({
+      query: id => `/rentals/${id}`,
+    }),
+    updateRentalStatus: builder.mutation({
+      query: ({ id, status }) => ({
+        url: `/rentals/${id}/status`,
+        method: 'PATCH',
+        body: { status },
+      }),
+    }),
+  }),
+});
+
+export const {
+  useGetRentalsQuery,
+  useGetRentalsByUserQuery,
+  useGetRentalHistoryByUserQuery,
+  useGetRentalByIdQuery,
+  useUpdateRentalStatusMutation,
+} = rentalsApi;

--- a/frontend/store/store.js
+++ b/frontend/store/store.js
@@ -1,0 +1,21 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { bikesApi } from './services/bikesApi';
+import { rentalsApi } from './services/rentalsApi';
+import { adminApi } from './services/adminApi';
+import { authApi } from './services/authApi';
+
+export const store = configureStore({
+  reducer: {
+    [bikesApi.reducerPath]: bikesApi.reducer,
+    [rentalsApi.reducerPath]: rentalsApi.reducer,
+    [adminApi.reducerPath]: adminApi.reducer,
+    [authApi.reducerPath]: authApi.reducer,
+  },
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware().concat(
+      bikesApi.middleware,
+      rentalsApi.middleware,
+      adminApi.middleware,
+      authApi.middleware,
+    ),
+});


### PR DESCRIPTION
## Summary
- add rental details and update status endpoints in `rentalsApi`
- expose couriers data through `adminApi`
- refactor order pages and tabs to use RTK Query hooks
- fetch corporate and courier lists with RTK Query
- integrate auth flows with new `authApi`

## Testing
- `npm test` *(fails: package.json missing)*
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cfe19b0708326ae64d069c2b1ff44