### PR TITLE
Add Jest to frontend

### DIFF
--- a/frontend/components/common/__tests__/Accordion.test.jsx
+++ b/frontend/components/common/__tests__/Accordion.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Accordion from '../Accordion';
+
+const faqs = [{ question: 'Question?', answer: 'Answer.' }];
+
+test('renders question text', () => {
+  render(<Accordion faqs={faqs} />);
+  expect(screen.getByText('Question?')).toBeInTheDocument();
+});

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,15 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  testEnvironment: 'jest-environment-jsdom',
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "lint:fix": "next lint --fix && npm run format",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css,scss,md,json}\"",
-    "export": "next export"
+    "export": "next export",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -20,6 +21,7 @@
     "@mui/material": "^6.4.6",
     "@popperjs/core": "^2.11.8",
     "@react-google-maps/api": "^2.19.3",
+    "@reduxjs/toolkit": "^2.2.3",
     "@tabler/icons-react": "^3.31.0",
     "autoprefixer": "^10.4.20",
     "bootstrap": "^5.0.2",
@@ -35,8 +37,6 @@
     "primereact": "^10.9.2",
     "prop-types": "^15.8.1",
     "rc-slider": "^11.1.6",
-    "@reduxjs/toolkit": "^2.2.3",
-    "react-redux": "^9.1.2",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0",
@@ -46,6 +46,7 @@
     "react-input-mask": "^2.0.4",
     "react-modal-video": "^2.0.2",
     "react-photoswipe-gallery": "^3.0.2",
+    "react-redux": "^9.1.2",
     "react-slick": "^0.30.2",
     "sass": "^1.78.0",
     "slick-carousel": "^1.8.1",
@@ -57,6 +58,11 @@
     "eslint-config-next": "15.3.3",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.5.0",
-    "prettier": "^3.5.3"
+    "prettier": "^3.5.3",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest dev setup with next/jest
- configure jest environment and script
- add simple Accordion component test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687de2b333708326953d72144a70b367