### PR TITLE
Add Mantine provider and font setup

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -50,3 +50,9 @@ The frontend now follows the [Feature‑Sliced Design](https://feature-sliced.de
 - `src/widgets` – page-level widgets (currently empty).
 
 Existing imports continue to resolve through the `@` alias that points to `src/`.
+
+## UI Library
+
+The application now integrates [Mantine](https://mantine.dev/) as the main UI
+framework. `MantineProvider` is configured in `src/app/layout.jsx` with Roboto as
+the default font family.

--- a/frontend/src/app/layout.jsx
+++ b/frontend/src/app/layout.jsx
@@ -1,5 +1,6 @@
 'use client';
 import React from 'react';
+import { MantineProvider } from '@mantine/core';
 import FilterSidebar from '@/ui/common/FilterSidebar';
 import '@public/main.scss';
 import 'photoswipe/dist/photoswipe.css';
@@ -25,16 +26,22 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en" className={roboto.className}>
       <body>
-        <Provider store={store}>
-          <I18nextProvider i18n={i18n}>
-            <RootContext>
-              <MobileMenu />
-              <div className="boxcar-wrapper">{children}</div>
-              <FilterSidebar />
-            </RootContext>
-            <BackToTop />
-          </I18nextProvider>
-        </Provider>
+        <MantineProvider
+          withGlobalStyles
+          withNormalizeCSS
+          theme={{ fontFamily: roboto.style.fontFamily }}
+        >
+          <Provider store={store}>
+            <I18nextProvider i18n={i18n}>
+              <RootContext>
+                <MobileMenu />
+                <div className="boxcar-wrapper">{children}</div>
+                <FilterSidebar />
+              </RootContext>
+              <BackToTop />
+            </I18nextProvider>
+          </Provider>
+        </MantineProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- wrap the Next.js app with `MantineProvider`
- configure default font family and document Mantine in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f286c5b4083269abcc5338da7221e